### PR TITLE
#67 [feat] : Fragment Title 레이아웃 MainActivity로 이동

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -8,7 +8,6 @@
     <application
         android:name=".GlobalApplication"
         android:allowBackup="true"
-        android:usesCleartextTraffic="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name_kor"
         android:roundIcon="@mipmap/ic_launcher_round"

--- a/app/src/main/java/com/dlab/sinsungo/MainActivity.kt
+++ b/app/src/main/java/com/dlab/sinsungo/MainActivity.kt
@@ -16,10 +16,11 @@ class MainActivity : AppCompatActivity(), BottomNavigationView.OnNavigationItemS
         setContentView(binding.root)
 
         binding.bottomNavView.setOnNavigationItemSelectedListener(this)
-        binding.bottomNavView.selectedItemId = R.id.bottom_nav_menu_refrigerator
+        changeBottomNavMenu(R.id.bottom_nav_menu_refrigerator)
     }
 
     override fun onNavigationItemSelected(item: MenuItem): Boolean {
+        binding.tvFragmentTitle.text = item.title.toString()
         when (item.itemId) {
             R.id.bottom_nav_menu_refrigerator -> {
                 val fragment = RefrigeratorFragment()

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -7,6 +7,49 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/cv_main_title"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent">
+
+            <TextView
+                android:id="@+id/tv_fragment_title"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="16dp"
+                android:layout_marginTop="16dp"
+                android:layout_marginBottom="20dp"
+                android:textAppearance="@style/Text.Bold_32_Blue"
+                app:layout_constraintBottom_toBottomOf="@id/cv_main_title"
+                app:layout_constraintStart_toStartOf="@id/cv_main_title"
+                app:layout_constraintTop_toTopOf="@id/cv_main_title" />
+
+            <ImageView
+                android:id="@+id/iv_userinfo"
+                android:layout_width="24dp"
+                android:layout_height="24dp"
+                android:layout_marginTop="16dp"
+                android:layout_marginEnd="16dp"
+                android:layout_marginBottom="20dp"
+                android:src="@drawable/btn_userinfo"
+                app:layout_constraintBottom_toBottomOf="@id/cv_main_title"
+                app:layout_constraintEnd_toEndOf="@id/cv_main_title"
+                app:layout_constraintTop_toTopOf="@id/cv_main_title" />
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+        <View
+            android:id="@+id/title_underbar"
+            android:layout_width="match_parent"
+            android:layout_height="0.5dp"
+            android:background="@color/dim_grey"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/cv_main_title" />
+
         <FrameLayout
             android:id="@+id/main_frame"
             android:layout_width="match_parent"
@@ -14,7 +57,7 @@
             app:layout_constraintBottom_toTopOf="@+id/bottom_nav_view"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
+            app:layout_constraintTop_toBottomOf="@id/title_underbar" />
 
         <com.google.android.material.bottomnavigation.BottomNavigationView
             android:id="@+id/bottom_nav_view"

--- a/app/src/main/res/layout/fragment_refrigerator.xml
+++ b/app/src/main/res/layout/fragment_refrigerator.xml
@@ -7,36 +7,23 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 
-        <TextView
-            android:id="@+id/tv_fragment_title"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="16dp"
-            android:layout_marginTop="39dp"
-            android:text="@string/all_refrigerator"
-            android:textAppearance="@style/Text.Bold_32_Blue"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
-
-        <ImageView
-            android:id="@+id/iv_userinfo"
-            android:layout_width="24dp"
-            android:layout_height="24dp"
-            android:layout_marginEnd="16dp"
-            android:src="@drawable/btn_userinfo"
-            app:layout_constraintBottom_toBottomOf="@+id/tv_fragment_title"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintTop_toTopOf="@+id/tv_fragment_title" />
-
         <com.google.android.material.tabs.TabLayout
             android:id="@+id/tablayout_refrigerator"
             style="@style/TabLayout.Refrigerator"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginTop="23dp"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/tv_fragment_title" />
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <View
+            android:id="@+id/line_tablayout_underbar"
+            android:layout_width="match_parent"
+            android:layout_height="0.5dp"
+            android:background="@color/dim_grey"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tablayout_refrigerator" />
 
         <androidx.viewpager2.widget.ViewPager2
             android:id="@+id/pager_ingredient"
@@ -45,7 +32,7 @@
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/tablayout_refrigerator" />
+            app:layout_constraintTop_toBottomOf="@+id/line_tablayout_underbar" />
 
         <com.leinardi.android.speeddial.SpeedDialOverlayLayout
             android:id="@+id/sdv_overlay"


### PR DESCRIPTION
## 개요
Fragment Title 레이아웃 MainActivity로 이동
## 작업 내용
Fragment Title 레이아웃 MainActivity로 이동
바텀 네비게이션 따라 Title 바뀌도록 연동

## 변경사항
+ 냉장고 프래그먼트에서 레이아웃 수정 적용 완료
<img width="451" alt="스크린샷 2021-04-28 오후 2 46 15" src="https://user-images.githubusercontent.com/58630483/116352679-7f259c80-a830-11eb-8848-5217721483ea.png">

## 주요로직
바텀네비게이션 아이템 선택시 메뉴 타이틀로 텍스트뷰 텍스트 설정
메인 액티비티 초기화때 네비게이션 아이템 설정 함수 호출 사용

Closes #67 