### PR TITLE
#109 [feat] : 재료 리사이클러뷰 정렬 구현

### DIFF
--- a/app/src/main/java/com/dlab/sinsungo/IngredientFragment.kt
+++ b/app/src/main/java/com/dlab/sinsungo/IngredientFragment.kt
@@ -3,8 +3,11 @@ package com.dlab.sinsungo
 import android.os.Bundle
 import android.util.Log
 import android.view.LayoutInflater
+import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
+import androidx.annotation.MenuRes
+import androidx.appcompat.widget.PopupMenu
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -20,19 +23,21 @@ class IngredientFragment(private val refCategory: String) : Fragment() {
         binding = FragmentIngredientBinding.inflate(inflater, container, false)
 
         initViewModel()
+        initSortMenu()
+
         getIngredients(5, refCategory)
-
-        return binding.root
-    }
-
-    fun initViewModel() {
-        viewModelFactory = IngredientViewModelFactory(IngredientRepository())
-        viewModel = ViewModelProvider(this, viewModelFactory).get(IngredientViewModel::class.java)
 
         viewModel.ingredients.observe(viewLifecycleOwner) {
             initRcView(it)
             Log.d("cur data", it.toString())
         }
+
+        return binding.root
+    }
+
+    private fun initViewModel() {
+        viewModelFactory = IngredientViewModelFactory(IngredientRepository())
+        viewModel = ViewModelProvider(this, viewModelFactory).get(IngredientViewModel::class.java)
     }
 
     private fun initRcView(ingredients: List<IngredientModel>) {
@@ -48,6 +53,25 @@ class IngredientFragment(private val refCategory: String) : Fragment() {
             }
         }
         binding.listSize = ingredients.size
+    }
+
+    private fun initSortMenu() {
+        binding.clIngredientSort.setOnClickListener { view: View ->
+            showSortMenu(view, R.menu.menu_ingredient_sortby)
+        }
+    }
+
+    private fun showSortMenu(view: View, @MenuRes menuRes: Int) {
+        val popup = PopupMenu(requireContext(), view)
+        popup.menuInflater.inflate(menuRes, popup.menu)
+
+        popup.setOnMenuItemClickListener { menuItem: MenuItem ->
+            binding.tvSort.text = menuItem.title
+            viewModel.sortList(menuItem.title.toString())
+            true
+        }
+
+        popup.show()
     }
 
     private fun getIngredients(refID: Int, refCategory: String) {

--- a/app/src/main/java/com/dlab/sinsungo/IngredientListAdapter.kt
+++ b/app/src/main/java/com/dlab/sinsungo/IngredientListAdapter.kt
@@ -47,13 +47,17 @@ class IngredientListAdapter(var ingredientList: List<IngredientModel>) :
     }
 
     fun update(updated: List<IngredientModel>) {
-        CoroutineScope(Dispatchers.Main).launch {
+        /*CoroutineScope(Dispatchers.Main).launch {
             val diffResult = async(Dispatchers.IO) {
                 getDiffResult(updated)
             }
             ingredientList = updated
             diffResult.await().dispatchUpdatesTo(this@IngredientListAdapter)
-        }
+        }*/
+        // 코루틴으로 구현시 동작 안
+        val diffResult = getDiffResult(updated)
+        diffResult.dispatchUpdatesTo(this)
+        ingredientList = updated
     }
 
     private fun getDiffResult(updated: List<IngredientModel>): DiffUtil.DiffResult {

--- a/app/src/main/java/com/dlab/sinsungo/IngredientViewModel.kt
+++ b/app/src/main/java/com/dlab/sinsungo/IngredientViewModel.kt
@@ -35,4 +35,22 @@ class IngredientViewModel(private val ingredientRepository: IngredientRepository
 
         _ingredients.postValue(filteredList)
     }
+
+    fun sortList(key: String) {
+        CoroutineScope(Dispatchers.Main).launch {
+            var data = _ingredients.value
+
+            when (key) {
+                "재료명 순" -> data = data!!.sortedBy { it.name }
+                "신선도 순" -> {
+                    val exDateList = data!!.filter { it.exdateType == "유통기한" }
+                    val notExDateList = data.filter { it.exdateType != "유통기한" }
+                    data = exDateList.sortedBy { it.exdate } + notExDateList.sortedBy { it.exdate }
+                }
+                "최근 추가 순" -> data = data!!.sortedBy { it.id }
+            }
+
+            _ingredients.postValue(data!!)
+        }
+    }
 }

--- a/app/src/main/res/layout/fragment_ingredient.xml
+++ b/app/src/main/res/layout/fragment_ingredient.xml
@@ -15,22 +15,34 @@
         android:layout_height="match_parent"
         android:padding="16dp">
 
-        <ImageView
-            android:id="@+id/iv_sort"
-            android:layout_width="24dp"
-            android:layout_height="24dp"
-            android:src="@drawable/btn_sort"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
-
-        <TextView
-            android:id="@+id/tv_sort"
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/cl_ingredient_sort"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginStart="8dp"
-            app:layout_constraintBottom_toBottomOf="@+id/iv_sort"
-            app:layout_constraintStart_toEndOf="@+id/iv_sort"
-            app:layout_constraintTop_toTopOf="@+id/iv_sort" />
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent">
+
+            <ImageView
+                android:id="@+id/iv_sort"
+                android:layout_width="24dp"
+                android:layout_height="24dp"
+                android:src="@drawable/btn_sort"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <TextView
+                android:id="@+id/tv_sort"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="8dp"
+                android:text="@string/ref_sortby_recent"
+                android:textAppearance="@style/Text.Regular_13_Black"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintStart_toEndOf="@+id/iv_sort"
+                app:layout_constraintTop_toTopOf="parent" />
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
 
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/rcview_ingredient"
@@ -39,7 +51,7 @@
             android:layout_marginTop="16dp"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/iv_sort" />
+            app:layout_constraintTop_toBottomOf="@+id/cl_ingredient_sort" />
 
         <androidx.constraintlayout.widget.ConstraintLayout
             android:id="@+id/layout_describe_image"

--- a/app/src/main/res/menu/menu_ingredient_sortby.xml
+++ b/app/src/main/res/menu/menu_ingredient_sortby.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android">
+    <item
+        android:id="@+id/ingredient_sortby_name"
+        android:title="@string/ref_sortby_name" />
+    <item
+        android:id="@+id/ingredient_sortby_fresh"
+        android:title="@string/ref_sortby_fresh" />
+    <item
+        android:id="@+id/ingredient_sortby_recent"
+        android:title="@string/ref_sortby_recent" />
+</menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -69,12 +69,9 @@
         <item>상온</item>
         <item>조미료/양념</item>
     </string-array>
-    <string-array name="ref_sort_types">
-        <item>유통기한 임박 순</item>
-        <item>재료명 순</item>
-        <item>수량 순</item>
-        <item>최근 추가 순</item>
-    </string-array>
+    <string name="ref_sortby_name">재료명 순</string>
+    <string name="ref_sortby_fresh">신선도 순</string>
+    <string name="ref_sortby_recent">최근 추가 순</string>
     <string name="ref_category_cold">냉장</string>
     <string name="ref_category_iced">냉동</string>
     <string name="ref_category_fresh">신선</string>


### PR DESCRIPTION
## 개요
재료 리사이클러뷰 정렬 구현

## 작업 내용
ViewModel에서 list sortedBy 함수 사용
정렬 항목 팝업메뉴 구현

## 변경사항
DiffUtil 코루틴내에서 동작 안하게 변경
Strings.xml 정렬 항목 array -> item 으로 변경

## 주요로직
신선도 순 정렬 로직
<img width="608" alt="스크린샷 2021-05-04 오후 1 22 02" src="https://user-images.githubusercontent.com/58630483/116960557-b9cd8000-acdb-11eb-8e92-4157466a2d7f.png">

Closes #109 