### PR TITLE
재료 직접입력 추가하기 기능 구현

### DIFF
--- a/app/src/main/java/com/dlab/sinsungo/CustomFragmentStateAdapter.kt
+++ b/app/src/main/java/com/dlab/sinsungo/CustomFragmentStateAdapter.kt
@@ -2,15 +2,18 @@ package com.dlab.sinsungo
 
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
+import androidx.fragment.app.FragmentManager
+import androidx.lifecycle.Lifecycle
 import androidx.viewpager2.adapter.FragmentStateAdapter
 
-class CustomFragmentStateAdapter(fragmentActivity: FragmentActivity) : FragmentStateAdapter(fragmentActivity) {
+class CustomFragmentStateAdapter(fragmentManager: FragmentManager, lifecycle: Lifecycle) :
+    FragmentStateAdapter(fragmentManager, lifecycle) {
     override fun getItemCount(): Int {
         return 5
     }
 
     override fun createFragment(position: Int): Fragment {
-        return when(position) {
+        return when (position) {
             0 -> IngredientFragment("냉장")
             1 -> IngredientFragment("냉동")
             2 -> IngredientFragment("신선")

--- a/app/src/main/java/com/dlab/sinsungo/IngredientAPI.kt
+++ b/app/src/main/java/com/dlab/sinsungo/IngredientAPI.kt
@@ -1,12 +1,19 @@
 package com.dlab.sinsungo
 
 import retrofit2.Response
+import retrofit2.http.Body
 import retrofit2.http.GET
+import retrofit2.http.POST
 import retrofit2.http.Path
 
-interface IngredientApi {
+interface IngredientAPI {
     @GET("/refrigerator/ingredient/{id}")
     suspend fun getIngredient(
         @Path("id") refID: Int
     ): Response<List<IngredientModel>>
+
+    @POST("/refrigerator/ingredient/")
+    suspend fun postIngredient(
+        @Body ingredientModel: IngredientModel
+    ): Response<IngredientModel>
 }

--- a/app/src/main/java/com/dlab/sinsungo/IngredientModel.kt
+++ b/app/src/main/java/com/dlab/sinsungo/IngredientModel.kt
@@ -14,7 +14,7 @@ data class IngredientModel(
     val count: Int,
 
     @SerializedName("expiration_date")
-    val exdate: Date,
+    val exdate: String,
 
     @SerializedName("category")
     val refCategory: String,

--- a/app/src/main/java/com/dlab/sinsungo/IngredientRepository.kt
+++ b/app/src/main/java/com/dlab/sinsungo/IngredientRepository.kt
@@ -4,5 +4,5 @@ object IngredientRepository {
     private val client = IngredientService.client
 
     suspend fun getIngredient(refID: Int) = client.getIngredient(refID)
-    // suspend fun postIngredient(ingredientModel: IngredientModel) = client.postIngredient(ingredientModel)
+    suspend fun postIngredient(ingredientModel: IngredientModel) = client.postIngredient(ingredientModel)
 }

--- a/app/src/main/java/com/dlab/sinsungo/RefrigeratorFragment.kt
+++ b/app/src/main/java/com/dlab/sinsungo/RefrigeratorFragment.kt
@@ -6,6 +6,7 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.core.content.res.ResourcesCompat
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
 import com.dlab.sinsungo.databinding.FragmentRefrigeratorBinding
 import com.google.android.material.floatingactionbutton.FloatingActionButton
 import com.google.android.material.tabs.TabLayoutMediator
@@ -14,6 +15,7 @@ import com.leinardi.android.speeddial.SpeedDialView
 
 class RefrigeratorFragment : Fragment(), SpeedDialView.OnActionSelectedListener {
     private lateinit var binding: FragmentRefrigeratorBinding
+    private val viewModel: IngredientViewModel by viewModels()
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         binding = FragmentRefrigeratorBinding.inflate(inflater, container, false)
@@ -25,7 +27,10 @@ class RefrigeratorFragment : Fragment(), SpeedDialView.OnActionSelectedListener 
 
     private fun initTabLayout() {
         val tabTextList = resources.getStringArray(R.array.ref_categories)
-        binding.pagerIngredient.adapter = CustomFragmentStateAdapter(requireActivity())
+        binding.pagerIngredient.apply {
+            adapter = CustomFragmentStateAdapter(childFragmentManager, lifecycle)
+            offscreenPageLimit = 4
+        }
         TabLayoutMediator(binding.tablayoutRefrigerator, binding.pagerIngredient) { tab, position ->
             tab.text = tabTextList[position]
         }.attach()
@@ -72,9 +77,8 @@ class RefrigeratorFragment : Fragment(), SpeedDialView.OnActionSelectedListener 
     override fun onActionSelected(actionItem: SpeedDialActionItem?): Boolean {
         when (actionItem?.id) {
             R.id.fab_custom_edit -> {
-                // openRefrigeratorDialog()
                 val dialog = RefrigeratorCustomDialog()
-                dialog.show(requireActivity().supportFragmentManager, "refrigerator_custom_dialog")
+                dialog.show(childFragmentManager, "refrigerator_custom_dialog")
                 binding.sdvRefrigerator.close()
             }
         }

--- a/app/src/main/res/layout/fragment_ingredient.xml
+++ b/app/src/main/res/layout/fragment_ingredient.xml
@@ -8,6 +8,14 @@
         <variable
             name="listSize"
             type="int" />
+
+        <variable
+            name="viewmodel"
+            type="com.dlab.sinsungo.IngredientViewModel" />
+
+        <variable
+            name="category"
+            type="String" />
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
@@ -47,8 +55,11 @@
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/rcview_ingredient"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
+            android:layout_height="0dp"
             android:layout_marginTop="16dp"
+            app:ingredientData="@{viewmodel.ingredients}"
+            app:category="@{category}"
+            app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/cl_ingredient_sort" />

--- a/app/src/main/res/layout/item_rcview_ingredient.xml
+++ b/app/src/main/res/layout/item_rcview_ingredient.xml
@@ -12,10 +12,6 @@
         <variable
             name="remain"
             type="Long" />
-
-        <variable
-            name="vm"
-            type="com.dlab.sinsungo.IngredientViewModel" />
     </data>
 
     <com.google.android.material.card.MaterialCardView
@@ -94,7 +90,7 @@
                 android:layout_height="wrap_content"
                 android:layout_marginTop="8dp"
                 android:textAppearance="@style/Text.Regular_10_Black"
-                app:exDateFormat="@{data.exdate}"
+                app:text="@{data.exdate}"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintTop_toBottomOf="@+id/pb_ingredient_exdate_remain" />
 


### PR DESCRIPTION
## 개요
재료 직접입력 추가하기 기능 구현

## 작업 내용
재료 수기로 추가하는 기능의 구현

## 변경사항
뷰모델의 선언과 공유

### 변경후
뷰모델을 부모-자식 프래그먼트가 한개를 공유하도록 구현
뷰모델 선언 부분 수정

## 주요로직
재료 추가 다이얼로그에서 확인 버튼 클릭 시 뷰모델의 post 함수 실행
응답을 받으면 postflag에 의해 다이얼로그 dismiss
추가한 모델은 라이브 데이터의 리스트에 추가
라이브 데이터 -> 리사이클러뷰에 바인딩되어 있어 변화 시 ui 업데이트

Closes #151 
Closes #152 
Closes #153 
Closes #154 
Closes #155 
Closes #156 