### PR TITLE
#204 [feat] : 재료 ViewModel 액티비티로 이동

### DIFF
--- a/app/src/main/java/com/dlab/sinsungo/IngredientFragment.kt
+++ b/app/src/main/java/com/dlab/sinsungo/IngredientFragment.kt
@@ -9,13 +9,14 @@ import android.view.ViewGroup
 import androidx.annotation.MenuRes
 import androidx.appcompat.widget.PopupMenu
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.viewModels
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.dlab.sinsungo.databinding.FragmentIngredientBinding
 
 class IngredientFragment(private val refCategory: String) : Fragment() {
     private lateinit var binding: FragmentIngredientBinding
-    private val viewModel: IngredientViewModel by viewModels(ownerProducer = { requireParentFragment() })
+    private val viewModel: IngredientViewModel by activityViewModels()
     private lateinit var mIngredientListAdapter: IngredientListAdapter
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {

--- a/app/src/main/java/com/dlab/sinsungo/IngredientViewModel.kt
+++ b/app/src/main/java/com/dlab/sinsungo/IngredientViewModel.kt
@@ -68,6 +68,8 @@ class IngredientViewModel : ViewModel() {
                                 _innerList.add(it)
                                 _ingredients.postValue(_innerList)
                                 Log.d("add ing item", it.toString())
+                                _inputIngredient.postValue(IngredientModel(null, "", 0, "", "냉장", "g", "유통기한"))
+                                _dialogDismissFlag.postValue(true)
                             }
                         }
                     } else {
@@ -96,12 +98,15 @@ class IngredientViewModel : ViewModel() {
                                 Log.d("update ing item", it.toString())
                                 _innerList[position!!] = it
                                 _ingredients.postValue(_innerList)
+                                _inputIngredient.postValue(IngredientModel(null, "", 0, "", "냉장", "g", "유통기한"))
+                                _dialogDismissFlag.postValue(true)
                             }
                         }
                     } else {
                         Log.e("put ing not success", response.message())
                     }
                 }
+
             } catch (e: IOException) {
                 Log.e("put ing ioexception", e.message.toString())
                 e.printStackTrace()
@@ -141,8 +146,6 @@ class IngredientViewModel : ViewModel() {
             true -> requestPutIngredient() // 수정
             false -> requestPostIngredient() // 추가
         }
-        _inputIngredient.postValue(IngredientModel(null, "", 0, "", "냉장", "g", "유통기한"))
-        _dialogDismissFlag.postValue(true)
     }
 
     // 다이얼로그 취소 버튼

--- a/app/src/main/java/com/dlab/sinsungo/MainActivity.kt
+++ b/app/src/main/java/com/dlab/sinsungo/MainActivity.kt
@@ -2,6 +2,7 @@ package com.dlab.sinsungo
 
 import android.os.Bundle
 import android.view.MenuItem
+import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
 import com.dlab.sinsungo.databinding.ActivityMainBinding
@@ -10,6 +11,8 @@ import com.google.android.material.bottomnavigation.BottomNavigationView
 
 class MainActivity : AppCompatActivity(), BottomNavigationView.OnNavigationItemSelectedListener {
     private lateinit var binding: ActivityMainBinding
+    private val ingredientViewModel: IngredientViewModel by viewModels()
+
     override fun onCreate(savedInstanceState: Bundle?) {
         setTheme(R.style.Theme_Sinsungo)
         super.onCreate(savedInstanceState)

--- a/app/src/main/java/com/dlab/sinsungo/RefrigeratorFragment.kt
+++ b/app/src/main/java/com/dlab/sinsungo/RefrigeratorFragment.kt
@@ -6,6 +6,7 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.core.content.res.ResourcesCompat
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.viewModels
 import com.dlab.sinsungo.databinding.FragmentRefrigeratorBinding
 import com.google.android.material.floatingactionbutton.FloatingActionButton
@@ -15,7 +16,7 @@ import com.leinardi.android.speeddial.SpeedDialView
 
 class RefrigeratorFragment : Fragment(), SpeedDialView.OnActionSelectedListener {
     private lateinit var binding: FragmentRefrigeratorBinding
-    private val viewModel: IngredientViewModel by viewModels()
+    private val viewModel: IngredientViewModel by activityViewModels()
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         binding = FragmentRefrigeratorBinding.inflate(inflater, container, false)

--- a/app/src/main/java/com/dlab/sinsungo/RefrigeratorSelfInputIngredientDialog.kt
+++ b/app/src/main/java/com/dlab/sinsungo/RefrigeratorSelfInputIngredientDialog.kt
@@ -17,6 +17,7 @@ import androidx.annotation.MenuRes
 import androidx.core.content.ContextCompat
 import androidx.core.content.res.ResourcesCompat
 import androidx.fragment.app.DialogFragment
+import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.viewModels
 import com.dlab.sinsungo.databinding.DialogSelfInputIngredientBinding
 import java.text.SimpleDateFormat
@@ -24,7 +25,7 @@ import java.util.*
 
 class RefrigeratorSelfInputIngredientDialog : DialogFragment() {
     private lateinit var binding: DialogSelfInputIngredientBinding
-    private val viewModel: IngredientViewModel by viewModels(ownerProducer = { requireParentFragment() })
+    private val viewModel: IngredientViewModel by activityViewModels()
 
     private val mCalendar = Calendar.getInstance()
 


### PR DESCRIPTION
## 개요
재료 ViewModel 액티비티로 이동

## 작업 내용
재료 ViewModel MainActivity에서 초기화
초기화와 동시에 get api 호출 (init 함수)
모든 하위 프래그먼트에서 activitySharedViewModel로 공유

## 변경사항
하위 프래그먼트에서 액티비티 뷰모델 사용시 ~~~~ViewModel by activityViewModels()로 사용

Closes #204 