### PR TITLE
#20 로그인 기능 및 시작 로직 구현

### DIFF
--- a/app/src/main/java/com/dlab/sinsungo/CustomBindingAdapter.kt
+++ b/app/src/main/java/com/dlab/sinsungo/CustomBindingAdapter.kt
@@ -129,6 +129,7 @@ object CustomBindingAdapter {
     fun bindReceipt(recyclerView: RecyclerView, ingredients: List<IngredientModel>?) {
         val adapter = recyclerView.adapter as ReceiptListAdapter
         adapter.submitList(ingredients?.toMutableList())
+    }
 
     @BindingAdapter("tvDietDate")
     @JvmStatic

--- a/app/src/main/java/com/dlab/sinsungo/CustomInviteDialog.kt
+++ b/app/src/main/java/com/dlab/sinsungo/CustomInviteDialog.kt
@@ -1,0 +1,42 @@
+package com.dlab.sinsungo
+
+import android.app.AlertDialog
+import android.app.Dialog
+import android.content.Intent
+import android.graphics.Color
+import android.graphics.drawable.ColorDrawable
+import android.os.Bundle
+import android.view.WindowManager
+import androidx.fragment.app.DialogFragment
+import androidx.fragment.app.activityViewModels
+import com.dlab.sinsungo.databinding.DialogInviteBinding
+import com.dlab.sinsungo.viewmodel.TutorialViewModel
+
+class CustomInviteDialog : DialogFragment() {
+    private lateinit var binding: DialogInviteBinding
+    private val viewModel: TutorialViewModel by activityViewModels()
+
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        binding = DialogInviteBinding.inflate(layoutInflater)
+        binding.view = this
+        binding.lifecycleOwner = this
+
+        val dialog = AlertDialog.Builder(requireContext())
+            .setView(binding.root)
+            .create()
+        dialog.window?.setBackgroundDrawable(ColorDrawable(Color.TRANSPARENT))
+        dialog.window?.setLayout(WindowManager.LayoutParams.MATCH_PARENT, WindowManager.LayoutParams.WRAP_CONTENT)
+        dialog.setCanceledOnTouchOutside(false)
+
+        return dialog
+    }
+
+    fun accept() {
+        viewModel.inviteUser(binding.etInviteKey.text.toString()) {
+            val intent = Intent(context, MainActivity::class.java)
+            intent.flags =
+                (Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP)
+            startActivity(intent)
+        }
+    }
+}

--- a/app/src/main/java/com/dlab/sinsungo/MainActivity.kt
+++ b/app/src/main/java/com/dlab/sinsungo/MainActivity.kt
@@ -28,19 +28,19 @@ class MainActivity : AppCompatActivity(), BottomNavigationView.OnNavigationItemS
         binding.bottomNavView.setOnNavigationItemSelectedListener(this)
         changeBottomNavMenu(R.id.bottom_nav_menu_refrigerator)
 
-        FirebaseMessaging.getInstance().token.addOnCompleteListener(OnCompleteListener { task ->
-            if (!task.isSuccessful) {
-                Log.d("FCM", "Fetching FCM registration token failed", task.exception)
-                return@OnCompleteListener
-            }
-
-            // Get new FCM registration token
-            val token = task.result
-
-            // Log and toast
-            Log.d("FCM", token!!)
-            Toast.makeText(this, token, Toast.LENGTH_SHORT).show()
-        })
+//        FirebaseMessaging.getInstance().token.addOnCompleteListener(OnCompleteListener { task ->
+//            if (!task.isSuccessful) {
+//                Log.d("FCM", "Fetching FCM registration token failed", task.exception)
+//                return@OnCompleteListener
+//            }
+//
+//            // Get new FCM registration token
+//            val token = task.result
+//
+//            // Log and toast
+//            Log.d("FCM", token!!)
+//            Toast.makeText(this, token, Toast.LENGTH_SHORT).show()
+//        })
     }
 
     override fun onNavigationItemSelected(item: MenuItem): Boolean {

--- a/app/src/main/java/com/dlab/sinsungo/MySharedPreference.kt
+++ b/app/src/main/java/com/dlab/sinsungo/MySharedPreference.kt
@@ -2,6 +2,7 @@ package com.dlab.sinsungo
 
 import android.content.Context
 import android.content.SharedPreferences
+import com.dlab.sinsungo.data.model.User
 
 class MySharedPreference(context: Context) {
     private val PREFS_FILE_NAME = "prefs"
@@ -51,5 +52,9 @@ class MySharedPreference(context: Context) {
 
     fun setLong(key: String, value: Long) {
         prefs.edit().putLong(key, value).apply()
+    }
+
+    fun remove(key: String) {
+        prefs.edit().remove(key).apply()
     }
 }

--- a/app/src/main/java/com/dlab/sinsungo/SplashActivity.kt
+++ b/app/src/main/java/com/dlab/sinsungo/SplashActivity.kt
@@ -3,26 +3,49 @@ package com.dlab.sinsungo
 import android.content.Intent
 import android.os.Bundle
 import android.os.Handler
+import android.os.Looper
+import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import com.bumptech.glide.Glide
 import com.dlab.sinsungo.databinding.ActivitySplashBinding
+import com.dlab.sinsungo.ui.LoginActivity
+import com.dlab.sinsungo.viewmodel.SplashViewModel
 
 class SplashActivity : AppCompatActivity() {
     private lateinit var binding: ActivitySplashBinding
+    private val viewModel: SplashViewModel by viewModels()
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        init()
+
+        // 로그인 돼 있을 때
+        if (GlobalApplication.prefs.getString("userId") != "") {
+            viewModel.getCurrentUser()
+        } else { // 로그인 안 돼 있을 때
+            Glide.with(this).load(R.raw.logo).into(binding.ivLoading)
+            Handler(Looper.getMainLooper()).postDelayed({
+                startActivity(Intent(this, LoginActivity::class.java))
+                finish()
+            }, 4500)
+        }
+    }
+
+    private fun init() {
         binding = ActivitySplashBinding.inflate(layoutInflater)
+        binding.lifecycleOwner = this
         setContentView(binding.root)
 
-        // TODO: 로그인 되어 있는 상태일 경우
-        startActivity(Intent(this, TutorialActivity::class.java))
-        finish()
-        // TODO: 로그인 되어 있지 않은 상태일 경우
-        /*Glide.with(this).load(R.raw.logo).into(binding.ivLoading)
-        Handler().postDelayed({
-            startActivity(Intent(this, MainActivity::class.java))
+        viewModel.user.observe(this) {
+            val intent: Intent by lazy {
+                // 냉장고 있을 때
+                if (it.refId != null) Intent(this, MainActivity::class.java)
+                // 냉장고 없을 때
+                else Intent(this, TutorialActivity::class.java)
+            }
+            startActivity(intent)
             finish()
-        }, 4500)*/
-
+        }
     }
 }

--- a/app/src/main/java/com/dlab/sinsungo/TutorialActivity.kt
+++ b/app/src/main/java/com/dlab/sinsungo/TutorialActivity.kt
@@ -3,18 +3,22 @@ package com.dlab.sinsungo
 import android.content.Intent
 import android.os.Bundle
 import android.view.View
+import androidx.activity.viewModels
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
 import androidx.viewpager2.adapter.FragmentStateAdapter
 import androidx.viewpager2.widget.ViewPager2
 import com.dlab.sinsungo.databinding.ActivityTutorialBinding
+import com.dlab.sinsungo.viewmodel.TutorialViewModel
 
 class TutorialActivity : FragmentActivity() {
     private lateinit var binding: ActivityTutorialBinding
+    private val viewModel: TutorialViewModel by viewModels()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         binding = ActivityTutorialBinding.inflate(layoutInflater)
+        binding.lifecycleOwner = this
         setContentView(binding.root)
 
         initViewPager()
@@ -24,12 +28,15 @@ class TutorialActivity : FragmentActivity() {
         }
 
         binding.btnInviteStart.setOnClickListener {
-
+            val dialog = CustomInviteDialog()
+            dialog.show(supportFragmentManager, "custom_invite_dialog")
         }
 
         binding.btnNormalStart.setOnClickListener {
-            startActivity(Intent(this, MainActivity::class.java))
-            finish()
+            viewModel.createRefrigerator {
+                startActivity(Intent(this, MainActivity::class.java))
+                finish()
+            }
         }
     }
 

--- a/app/src/main/java/com/dlab/sinsungo/data/model/User.kt
+++ b/app/src/main/java/com/dlab/sinsungo/data/model/User.kt
@@ -10,11 +10,17 @@ data class User(
     val userId: String,
 
     @SerializedName("login_type")
-    val loginType: String?,
+    val loginType: String,
 
     @SerializedName("name")
-    val name: String?,
+    val name: String,
+
+    @SerializedName("push_token")
+    val pushToken: String?,
 
     @SerializedName("refrigerator_id")
-    val refId: Int?
+    val refId: Int?,
+
+    @SerializedName("push_setting")
+    val pushSetting: Int
 ) : Parcelable

--- a/app/src/main/java/com/dlab/sinsungo/ui/RecipeDetailActivity.kt
+++ b/app/src/main/java/com/dlab/sinsungo/ui/RecipeDetailActivity.kt
@@ -28,10 +28,6 @@ class RecipeDetailActivity : AppCompatActivity() {
         binding.lifecycleOwner = this
         binding.view = this
         binding.viewModel = viewModel
-
-        binding.root.viewTreeObserver.addOnGlobalLayoutListener {
-            binding.ivThumbnail.layoutParams.height = binding.ivThumbnail.measuredWidth
-        }
     }
 
     private fun setRecipeData() {

--- a/app/src/main/java/com/dlab/sinsungo/ui/RecipeFragment.kt
+++ b/app/src/main/java/com/dlab/sinsungo/ui/RecipeFragment.kt
@@ -14,6 +14,7 @@ import android.widget.TextView
 import androidx.fragment.app.viewModels
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
+import com.dlab.sinsungo.GlobalApplication
 import com.dlab.sinsungo.RecipeAdapter
 import com.dlab.sinsungo.data.model.Recipe
 import com.dlab.sinsungo.databinding.FragmentRecipeBinding
@@ -24,6 +25,7 @@ class RecipeFragment : Fragment() {
     private val viewModel: RecipeViewModel by viewModels()
     private lateinit var recipeAdapter: RecipeAdapter
     private lateinit var rvLayoutManager: LinearLayoutManager
+    private val refId = GlobalApplication.prefs.getInt("refId")
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         binding = FragmentRecipeBinding.inflate(inflater, container, false)
@@ -58,7 +60,7 @@ class RecipeFragment : Fragment() {
                 if (itemTotalCount > 20 && !binding.rvRecipe.canScrollVertically(1) && lastVisibleItemPosition == itemTotalCount - 1
                     && !viewModel.trigger
                 ) {
-                    viewModel.getRecipe(5, itemTotalCount - 1, 20, binding.etSearch.text.toString())
+                    viewModel.getRecipe(refId, itemTotalCount - 1, 20, binding.etSearch.text.toString())
                 }
             }
         })
@@ -70,7 +72,7 @@ class RecipeFragment : Fragment() {
                 if (actionId == EditorInfo.IME_ACTION_SEARCH) {
                     val inputMethodManager = activity!!.getSystemService(INPUT_METHOD_SERVICE) as InputMethodManager
 
-                    viewModel.enableSearch(5, 0, 20, binding.etSearch.text.toString())
+                    viewModel.enableSearch(refId, 0, 20, binding.etSearch.text.toString())
                     inputMethodManager.hideSoftInputFromWindow(binding.etSearch.windowToken, 0)
                     binding.etSearch.clearFocus()
 

--- a/app/src/main/java/com/dlab/sinsungo/viewmodel/LoginViewModel.kt
+++ b/app/src/main/java/com/dlab/sinsungo/viewmodel/LoginViewModel.kt
@@ -6,8 +6,9 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.dlab.sinsungo.Event
+import com.dlab.sinsungo.GlobalApplication
 import com.dlab.sinsungo.data.model.User
-import com.dlab.sinsungo.data.repository.LoginRepository
+import com.dlab.sinsungo.data.repository.UserRepository
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -26,17 +27,28 @@ class LoginViewModel : ViewModel() {
     }
 
     // 회원 가입 돼 있는지 확인
-    fun isRegister(userId: String, loginType: String, name: String?) {
-        val newUser = User(userId, loginType, name, null)
+    fun isRegister(userId: String, loginType: String, name: String, pushToken: String) {
+        val newUser = User(userId, loginType, name, pushToken, null, 1)
 
         // 코루틴으로 비동기로 LoginRepository.login 호출
         viewModelScope.launch(Dispatchers.IO) {
             try {
-                LoginRepository.login(newUser).let { it ->
+                UserRepository.login(newUser).let { it ->
                     if (it.isSuccessful) {
                         it.body()?.let { resUser ->
                             withContext(Dispatchers.Main) {
                                 _newUser.value = resUser
+                                var refId = 0
+                                var token = ""
+
+                                GlobalApplication.prefs.setString("userId", resUser.userId)
+                                GlobalApplication.prefs.setString("loginType", resUser.loginType)
+                                GlobalApplication.prefs.setString("name", resUser.name)
+                                GlobalApplication.prefs.setInt("pushSetting", resUser.pushSetting)
+                                resUser.pushToken?.let { token = it }
+                                resUser.refId?.let { refId = it }
+                                GlobalApplication.prefs.setString("pushToken", token)
+                                GlobalApplication.prefs.setInt("refId", refId)
                             }
                         }
                     } else {

--- a/app/src/main/java/com/dlab/sinsungo/viewmodel/RecipeViewModel.kt
+++ b/app/src/main/java/com/dlab/sinsungo/viewmodel/RecipeViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.dlab.sinsungo.GlobalApplication
 import com.dlab.sinsungo.data.model.Recipe
 import com.dlab.sinsungo.data.repository.RecipeRepository
 import kotlinx.coroutines.Dispatchers
@@ -23,7 +24,7 @@ class RecipeViewModel : ViewModel() {
     val trigger = _trigger
 
     init {
-        getRecipe(5, 0, 20)
+        getRecipe(GlobalApplication.prefs.getInt("refId"), 0, 20)
     }
 
     fun getRecipe(id: Int, start: Int, end: Int, query: String = "") {

--- a/app/src/main/java/com/dlab/sinsungo/viewmodel/SplashViewModel.kt
+++ b/app/src/main/java/com/dlab/sinsungo/viewmodel/SplashViewModel.kt
@@ -1,0 +1,53 @@
+package com.dlab.sinsungo.viewmodel
+
+import android.util.Log
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.dlab.sinsungo.GlobalApplication
+import com.dlab.sinsungo.data.model.User
+import com.dlab.sinsungo.data.repository.UserRepository
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import java.io.IOException
+
+class SplashViewModel : ViewModel() {
+    private val _user = MutableLiveData<User>()
+    val user: LiveData<User> = _user
+
+    fun getCurrentUser() {
+        val user = User(
+            GlobalApplication.prefs.getString("userId")!!,
+            GlobalApplication.prefs.getString("loginType")!!,
+            GlobalApplication.prefs.getString("name")!!,
+            GlobalApplication.prefs.getString("pushToken"),
+            GlobalApplication.prefs.getInt("refId"),
+            GlobalApplication.prefs.getInt("pushSetting")
+        )
+        viewModelScope.launch(Dispatchers.IO) {
+            try {
+                UserRepository.getUser(user).let { it ->
+                    if (it.isSuccessful) {
+                        it.body()?.let { res ->
+                            withContext(Dispatchers.Main) {
+                                _user.postValue(res)
+                                var refId = 0
+
+                                res.refId?.let { refId = it }
+                                GlobalApplication.prefs.setInt("refId", refId)
+                                GlobalApplication.prefs.setInt("pushSetting", res.pushSetting)
+                            }
+                        }
+                    } else {
+                        Log.e("user_error", it.message())
+                    }
+                }
+            } catch (e: IOException) {
+                Log.e("io_error", e.message!!)
+                e.printStackTrace()
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/dlab/sinsungo/viewmodel/TutorialViewModel.kt
+++ b/app/src/main/java/com/dlab/sinsungo/viewmodel/TutorialViewModel.kt
@@ -1,0 +1,78 @@
+package com.dlab.sinsungo.viewmodel
+
+import android.util.Log
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.dlab.sinsungo.GlobalApplication
+import com.dlab.sinsungo.data.model.Refrigerator
+import com.dlab.sinsungo.data.model.User
+import com.dlab.sinsungo.data.repository.RefrigeratorRepository
+import com.dlab.sinsungo.data.repository.UserRepository
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import java.io.IOException
+
+class TutorialViewModel : ViewModel() {
+
+    fun createRefrigerator(startMainActivity: () -> Unit) {
+        val refrigerator = Refrigerator(GlobalApplication.prefs.getString("userId")!!, "", null)
+        val body = HashMap<String, Any>()
+        body["loginType"] = GlobalApplication.prefs.getString("loginType")!!
+        body["refrigerator"] = refrigerator
+
+        viewModelScope.launch(Dispatchers.IO) {
+            try {
+                RefrigeratorRepository.createRefrigerator(body).let { it ->
+                    if (it.isSuccessful) {
+                        it.body()?.let { res ->
+                            GlobalApplication.prefs.setInt("refId", res["id"].asInt)
+                            startMainActivity()
+                        }
+                    } else {
+                        Log.e("refrigerator_error", it.message())
+                    }
+                }
+            } catch (e: IOException) {
+                Log.e("io_error", e.message!!)
+                e.printStackTrace()
+            }
+        }
+    }
+
+    fun inviteUser(inviteKey: String, startMainActivity: () -> Unit) {
+        val user = User(
+            GlobalApplication.prefs.getString("userId")!!,
+            GlobalApplication.prefs.getString("loginType")!!,
+            GlobalApplication.prefs.getString("name")!!,
+            GlobalApplication.prefs.getString("pushToken"),
+            GlobalApplication.prefs.getInt("refId"),
+            GlobalApplication.prefs.getInt("pushSetting")
+        )
+        val body = HashMap<String, Any>()
+        body["inviteKey"] = inviteKey
+        body["user"] = user
+
+        viewModelScope.launch(Dispatchers.IO) {
+            try {
+                UserRepository.invite(body).let { it ->
+                    if (it.isSuccessful) {
+                        it.body()?.let { res ->
+                            res.refId?.let {
+                                GlobalApplication.prefs.setInt("refId", it)
+                                startMainActivity()
+                            }
+                        }
+                    } else {
+                        Log.e("refrigerator_error", it.message())
+                    }
+                }
+            } catch (e: IOException) {
+                Log.e("io_error", e.message!!)
+                e.printStackTrace()
+            }
+        }
+    }
+}

--- a/app/src/main/res/drawable/img_login_logo.xml
+++ b/app/src/main/res/drawable/img_login_logo.xml
@@ -1,6 +1,6 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="144dp"
-    android:height="134.872dp"
+    android:width="180dp"
+    android:height="180dp"
     android:viewportWidth="144"
     android:viewportHeight="134.872">
   <path

--- a/app/src/main/res/layout/activity_login.xml
+++ b/app/src/main/res/layout/activity_login.xml
@@ -19,13 +19,12 @@
 
         <ImageView
             android:id="@+id/iv_logo"
+            app:layout_constraintVertical_bias="0.6"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:layout_marginBottom="95.13dp"
             android:src="@drawable/img_login_logo"
             app:layout_constraintBottom_toTopOf="@id/cl_btns"
             app:layout_constraintEnd_toEndOf="@id/guideline_end"
-            app:layout_constraintHorizontal_bias="0.5"
             app:layout_constraintStart_toStartOf="@id/guideline_start"
             app:layout_constraintTop_toTopOf="parent"
             app:layout_constraintVertical_chainStyle="packed" />
@@ -34,10 +33,10 @@
             android:id="@+id/cl_btns"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
+            android:layout_marginBottom="32dp"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="@+id/guideline_end"
-            app:layout_constraintStart_toStartOf="@+id/guideline_start"
-            app:layout_constraintTop_toBottomOf="@+id/iv_logo">
+            app:layout_constraintStart_toStartOf="@+id/guideline_start">
 
             <ImageView
                 android:id="@+id/btn_login_kakao"

--- a/app/src/main/res/layout/dialog_invite.xml
+++ b/app/src/main/res/layout/dialog_invite.xml
@@ -6,11 +6,7 @@
     <data>
         <variable
             name="view"
-            type="com.dlab.sinsungo.CustomConfirmDialog" />
-
-        <variable
-            name="viewModel"
-            type="com.dlab.sinsungo.viewmodel.MyPageViewModel" />
+            type="com.dlab.sinsungo.CustomInviteDialog" />
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
@@ -18,16 +14,13 @@
         android:layout_height="wrap_content"
         android:background="@color/white">
 
-        <TextView
-            android:id="@+id/tv_memo"
-            android:layout_width="wrap_content"
+        <EditText
+            android:id="@+id/et_invite_key"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:layout_marginTop="16dp"
-            android:textAppearance="@style/Text.Bold_14_Black"
-            app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintBottom_toTopOf="@+id/btn_cancel" />
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
 
         <Button
             android:id="@+id/btn_cancel"
@@ -40,19 +33,20 @@
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toStartOf="@id/btn_accept"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/tv_memo" />
+            app:layout_constraintTop_toBottomOf="@+id/et_invite_key" />
 
         <Button
             android:id="@+id/btn_accept"
             style="@style/Widget.MaterialComponents.Button.Dialog"
+            android:background="@color/royal_blue"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="@string/btn_accept"
             android:onClick="@{() -> view.accept()}"
+            android:text="@string/btn_accept"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toEndOf="@+id/btn_cancel"
-            app:layout_constraintTop_toBottomOf="@+id/tv_memo" />
+            app:layout_constraintTop_toBottomOf="@+id/et_invite_key"/>
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/app/src/main/res/layout/item_rcview_receipt_ocr.xml
+++ b/app/src/main/res/layout/item_rcview_receipt_ocr.xml
@@ -40,7 +40,7 @@
                 android:layout_height="wrap_content"
                 android:text="@{data.name}"
                 android:layout_marginStart="16dp"
-                android:textAppearance="@style/Text.Bold_14dp_Black"
+                android:textAppearance="@style/Text.Bold_14_Black"
                 app:layout_constraintStart_toEndOf="@id/btn_drop_item"
                 app:layout_constraintTop_toTopOf="parent" />
 


### PR DESCRIPTION
## 개요
로그인 기능 및 시작 로직 구현
## 작업 내용
로그인 액티비티 레이아웃 수정
로그인 화면 로고 크기 수정
스플래시-로그인-튜토리얼-메인 연결
recipe에서 실제 냉장고id 값으로 가져오게 수정
MySharedPreference에 remove 추가
파이어베이스 등록 토큰 받는 로직 로그인으로 이동
## 주요로직
로그인 안 돼 있으면 로그인 액티비티로 이동
로그인 돼 있으면 냉장고 확인 후 있으면 메인으로 이동, 없으면 튜토리얼로 이동
(스플래시에서 로그인 돼 있으면 현재 유저 값 db에서 가져와 냉장고 id 와 push setting 갱신해줌)

로그인 액티비티에서 로그인 후 냉장고 확인 후 있으면 메인으로 이동, 없으면 튜토리얼로 이동 (isFromSplash는 false)

튜토리얼 마지막에서 초대코드 입력하기 클릭 시 다이얼로그 띄우고 초대코드 입력시킴 (custom dialog 디자인 미구현)
시작하기 클릭 시 냉장고 생성하고 메인으로 이동

Closes #20 #232 