### PR TITLE
#305 [style] UI 수정

### DIFF
--- a/app/src/main/java/com/dlab/sinsungo/data/CustomBindingAdapter.kt
+++ b/app/src/main/java/com/dlab/sinsungo/data/CustomBindingAdapter.kt
@@ -12,11 +12,12 @@ import android.widget.ImageView
 import android.widget.ProgressBar
 import android.widget.TextView
 import androidx.core.content.res.ResourcesCompat
+import androidx.core.view.marginTop
 import androidx.databinding.BindingAdapter
 import androidx.databinding.BindingConversion
 import androidx.recyclerview.widget.RecyclerView
 import com.bumptech.glide.Glide
-import com.dlab.sinsungo.*
+import com.dlab.sinsungo.R
 import com.dlab.sinsungo.adapters.*
 import com.dlab.sinsungo.data.model.*
 import java.util.*
@@ -102,6 +103,14 @@ object CustomBindingAdapter {
     fun bindShopping(recyclerView: RecyclerView, shopping: List<Shopping>?) {
         val adapter = recyclerView.adapter as ShoppingListAdapter
         adapter.submitList(shopping?.toMutableList())
+    }
+
+    @BindingAdapter("shoppingItem")
+    @JvmStatic
+    fun bindShoppingItem(textView: TextView, value: String?) {
+        if (value == null || value == "") {
+            textView.visibility = View.GONE
+        }
     }
 
     @BindingAdapter("span_text", "span_color")

--- a/app/src/main/res/layout/activity_tutorial.xml
+++ b/app/src/main/res/layout/activity_tutorial.xml
@@ -38,7 +38,7 @@
             android:elevation="2dp"
             android:padding="16dp"
             android:text="@string/tutorial_skip"
-            android:textAppearance="@style/Text.Bold_20_Blue"
+            android:textAppearance="@style/Text.Bold_16_Blue"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintStart_toStartOf="parent" />
 

--- a/app/src/main/res/layout/item_rcview_diet.xml
+++ b/app/src/main/res/layout/item_rcview_diet.xml
@@ -29,14 +29,19 @@
                     android:id="@+id/btn_edit_diet"
                     android:layout_width="0dp"
                     android:layout_height="60dp"
-                    android:layout_marginEnd="5dp"
                     android:layout_weight="1"
                     android:background="@drawable/shape_dialog"
-                    android:backgroundTint="@color/lavender_blue"
                     android:contentDescription="@string/all_img_description"
                     android:elevation="16dp"
                     android:padding="16dp"
-                    android:src="@drawable/btn_edit" />
+                    android:src="@drawable/btn_edit"
+                    app:tint="@color/royal_blue" />
+
+                <View
+                    android:layout_width="1dp"
+                    android:layout_height="30dp"
+                    android:layout_gravity="center"
+                    android:background="@color/dim_grey" />
 
                 <ImageView
                     android:id="@+id/btn_delete_diet"
@@ -44,11 +49,11 @@
                     android:layout_height="60dp"
                     android:layout_weight="1"
                     android:background="@drawable/shape_dialog"
-                    android:backgroundTint="@color/free_speech_red"
                     android:contentDescription="@string/all_img_description"
                     android:elevation="16dp"
                     android:padding="16dp"
-                    android:src="@drawable/btn_trash" />
+                    android:src="@drawable/btn_trash"
+                    app:tint="@color/free_speech_red" />
             </LinearLayout>
         </FrameLayout>
 

--- a/app/src/main/res/layout/item_rcview_shopping_list.xml
+++ b/app/src/main/res/layout/item_rcview_shopping_list.xml
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools">
+    xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <data>
+
+        <import type="android.view.View" />
 
         <variable
             name="dataModel"
@@ -23,32 +24,40 @@
             <LinearLayout
                 android:layout_width="125dp"
                 android:layout_height="wrap_content"
+                android:layout_gravity="center"
                 android:orientation="horizontal">
 
                 <ImageView
                     android:id="@+id/btn_check_shopping"
                     android:layout_width="0dp"
                     android:layout_height="60dp"
-                    android:layout_marginEnd="5dp"
+                    android:layout_gravity="center"
                     android:layout_weight="1"
                     android:background="@drawable/shape_dialog"
-                    android:backgroundTint="@color/lavender_blue"
                     android:contentDescription="@string/all_img_description"
                     android:elevation="16dp"
                     android:padding="16dp"
-                    android:src="@drawable/btn_check" />
+                    android:src="@drawable/btn_check"
+                    app:tint="@color/royal_blue" />
+
+                <View
+                    android:layout_width="1dp"
+                    android:layout_height="30dp"
+                    android:layout_gravity="center"
+                    android:background="@color/dim_grey" />
 
                 <ImageView
                     android:id="@+id/btn_delete_shopping"
                     android:layout_width="0dp"
                     android:layout_height="60dp"
+                    android:layout_gravity="center"
                     android:layout_weight="1"
                     android:background="@drawable/shape_dialog"
-                    android:backgroundTint="@color/free_speech_red"
                     android:contentDescription="@string/all_img_description"
                     android:elevation="16dp"
                     android:padding="16dp"
-                    android:src="@drawable/btn_trash" />
+                    android:src="@drawable/btn_trash"
+                    app:tint="@color/free_speech_red" />
             </LinearLayout>
         </FrameLayout>
 
@@ -82,7 +91,8 @@
                     android:text="@{dataModel.shopMemo}"
                     android:textAppearance="@style/Text.Regular_10_Green"
                     app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@id/tv_rc_shopping_name" />
+                    app:layout_constraintTop_toBottomOf="@id/tv_rc_shopping_name"
+                    app:shoppingItem="@{dataModel.shopMemo}" />
 
                 <TextView
                     android:id="@+id/tv_ingredient_count"
@@ -97,8 +107,8 @@
 
                 <TextView
                     android:id="@+id/tv_unit"
-                    android:layout_width="24dp"
-                    android:layout_height="24dp"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
                     android:text="@{dataModel.shopUnit}"
                     android:textAppearance="@style/Text.Regular_20_Black"
                     app:layout_constraintBottom_toBottomOf="parent"


### PR DESCRIPTION
## 개요
UI 수정

## 작업 내용
- swipe 이미지 변경
- 장바구니 메모가 없을때 장바구니 아이템 명 가운데 정렬
- 튜토리얼에 건너뛰기 글씨 크기 변경
## 변경사항
### 변경후
<img width="467" alt="image" src="https://user-images.githubusercontent.com/45262992/131218529-6c4da962-b347-4097-b484-5dc24b3b65a0.png">
<img width="243" alt="image" src="https://user-images.githubusercontent.com/45262992/131218533-d7dbf2a2-70a5-4b23-a9a0-cb3b56ee79cb.png">

Closes #305 